### PR TITLE
specify python2

### DIFF
--- a/tidal-bootstrap.command
+++ b/tidal-bootstrap.command
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import sys


### PR DESCRIPTION
Changed header to specify python2 instead of system default which varies from user to user