### PR TITLE
Replace `haskell-platform` with `ghc cabal-install stack`

### DIFF
--- a/tidal-bootstrap.command
+++ b/tidal-bootstrap.command
@@ -138,7 +138,7 @@ def welcome():
 def install_dep(cmd, name):
     print "Installing:", name
     if name == 'ghci':
-        name = 'haskell-platform'
+        name = 'ghc cabal-install stack'
 
     command = cmd.split()
     command.append(name)


### PR DESCRIPTION
`haskwell-platform` was removed from the brew cask in favor of `ghc cabal-install stack`

https://github.com/Homebrew/homebrew-cask/pull/47908