### PR TITLE
Adds 2 changes to tidal-bootstrap.command for mac

### DIFF
--- a/tidal-bootstrap.command
+++ b/tidal-bootstrap.command
@@ -137,9 +137,6 @@ def welcome():
 # TODO: Make this parallel using subprocess.Popen
 def install_dep(cmd, name):
     print "Installing:", name
-    if name == 'ghci':
-        name = 'haskell-platform'
-
     command = cmd.split()
     command.append(name)
 
@@ -155,7 +152,13 @@ def install_app_dependencies(targets):
 
     for program in targets:
         name, ext = os.path.splitext(program)
-        install_dep('brew cask install', name.lower())
+        name = name.lower()
+        if name == 'ghci':
+            install_dep('brew install', 'ghc')
+            install_dep('brew install', 'cabal-install')
+            install_dep('brew install', 'stack')
+        else:
+            install_dep('brew cask install', name)
 
     print "\nAll app dependencies installed!"
 
@@ -227,6 +230,7 @@ def check_tidal():
         return True
     else:
         print "Installing tidal.."
+        return_code = subprocess.call(['cabal', 'update'])
         return_code = subprocess.call(['cabal', 'install', 'tidal'])
         if return_code != 0:
             print "Could not install tidal!"


### PR DESCRIPTION
I encountered following error when I executed `./tidal-bootstrap.command`.

```sh
Config file path source is default config file.
Config file /Users/tobias/.cabal/config not found.
Writing default configuration to /Users/tobias/.cabal/config
Warning: The package list for 'hackage.haskell.org' does not exist. Run 'cabal
update' to download it.
cabal: There is no package named 'tidal'.
You may need to run 'cabal update' to get the latest list of available
packages.

Could not install tidal!
Checking if tidal atom package is installed..
Installing tidalcycles to /Users/tobias/.atom/packages ✓
Checking if SuperDirt quark is installed..
SuperDirt quark was not found
Sorry, all packages could not be installed
Tidal cabal package could not be installed
Visit: http://tidalcycles.org/getting_started.html and install them using the instructions found there
Please open the file: install-superdirt-quark.scd in SuperCollider to install SuperDirt
```

I add 2 change to `tidal-bootstrap.command` to fix above errors.
1. Adds `cabal update` before `cable install tidal`
2. Changes `brew cask install haskell-platform` to `brew install ghc cabal-install stack`

`haskell-platform` is unavailable package in `brew` and `brew cask` . We get following error message when execute `brew install haskell-platform`:
```
$ brew cask install haskell-platform
Error: Cask 'haskell-platform' is unavailable: No Cask with this name exists.

$ brew install haskell-platform
Error: No available formula with the name "haskell-platform"
We no longer package haskell-platform. Consider installing ghc,
cabal-install and stack instead:
  brew install ghc cabal-install stack
```

My environment is:
os: os x 10.14.3
Homebrew: 2.0.2