### PR TITLE
fix: updated startup url

### DIFF
--- a/tidal-bootstrap.command
+++ b/tidal-bootstrap.command
@@ -302,6 +302,6 @@ echo "Tidal and SuperDirt should now be installed!\n\n"
 echo "Please log out and in again to complete the set up.\n\n"
 
 echo "You can then follow the instructions here to start everything up for the first time:"
-echo "  https://tidalcycles.org/index.php/Start_tidalcycles_and_superdirt_for_the_first_time"
+echo "  https://tidalcycles.org/docs/getting-started/tidal_start"
 echo "Enjoy!"
 exit 0


### PR DESCRIPTION
At the end of the script there is an outdated link to a page which guides new users on how to start tidal for the first time. It leads us to a page which no longer exists, so I updated the link.  
old: https://tidalcycles.org/index.php/Start_tidalcycles_and_superdirt_for_the_first_time  
new:  https://tidalcycles.org/docs/getting-started/tidal_start